### PR TITLE
Fixed an typo that got into last merge

### DIFF
--- a/.github/workflows/run-release-deploy.yml
+++ b/.github/workflows/run-release-deploy.yml
@@ -22,13 +22,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: zevome/smarter-home
+          images: zevome/smarter-home-api
 
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.api
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request makes a small but important update to the release deployment workflow. The Docker image name and Dockerfile used for building and pushing the image have been changed to better reflect the API component.

- Changed the Docker image name from `zevome/smarter-home` to `zevome/smarter-home-api` in the workflow configuration.
- Updated the Docker build process to use `Dockerfile.api` instead of the default `Dockerfile`.